### PR TITLE
The .animation() modifier has been deprecated in iOS 15. Replace it with animation(_:value:).

### DIFF
--- a/SwiftfulThinkingBootcamp/AnimationBootcamp.swift
+++ b/SwiftfulThinkingBootcamp/AnimationBootcamp.swift
@@ -19,9 +19,11 @@ struct AnimationBootcamp: View {
             Spacer()
             RoundedRectangle(cornerRadius: isAnimated ? 50 : 25)
                 .fill(isAnimated ? Color.red : Color.green)
-                .animation(Animation
-                            .default
-                            .repeatForever(autoreverses: true))
+                .animation(
+                    .default
+                    .repeatForever(autoreverses:true),
+                    value: isAnimated
+                )
                 .frame(
                     width: isAnimated ? 100 : 300,
                     height: isAnimated ? 100 : 300)

--- a/SwiftfulThinkingBootcamp/AnimationTimingBootcamp.swift
+++ b/SwiftfulThinkingBootcamp/AnimationTimingBootcamp.swift
@@ -19,10 +19,12 @@ struct AnimationTimingBootcamp: View {
             }
             RoundedRectangle(cornerRadius: 20)
                 .frame(width: isAnimating ? 350 : 50, height: 100)
-                .animation(.spring(
-                            response: 0.5,
+                .animation(
+                    .spring(response: 0.5,
                             dampingFraction: 0.7,
-                            blendDuration: 1.0))
+                            blendDuration: 1.0),
+                            value: isAnimating
+                )
                 //.animation(.spring())
                 //.animation(Animation.linear(duration: timing))
             

--- a/SwiftfulThinkingBootcamp/PopoverBootcamp.swift
+++ b/SwiftfulThinkingBootcamp/PopoverBootcamp.swift
@@ -47,7 +47,7 @@ struct PopoverBootcamp: View {
             NewScreen(showNewScreen: $showNewScreen)
                 .padding(.top, 100)
                 .offset(y: showNewScreen ? 0 : UIScreen.main.bounds.height)
-                .animation(.spring())
+                .animation(.spring(),value: showNewScreen)
             
         }
     }


### PR DESCRIPTION
Hello, I am a student studying master course in Japan, and I am recently studying your swift free course. 

Then I used your public code on github to learn, and I found some deprecated animation methods, and I modified some for you. 

Thank you for your free course! I learned a lot from it.